### PR TITLE
Add rehype-raw dependency for markdown <br> tag support

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "react-scripts": "5.0.1",
     "react-syntax-highlighter": "^15.5.0",
     "rehype-katex": "^7.0.1",
+    "rehype-raw": "^7.0.0",
     "remark-gfm": "^3.0.1",
     "remark-math": "^6.0.0"
   },


### PR DESCRIPTION
Added rehype-raw ^7.0.0 to support HTML raw content rendering in markdown, enabling proper handling of <br> line breaks in markdown content as implemented in the recent markdown line break matching update.